### PR TITLE
Add missing classes - allows the project to compile again

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+.idea/*
+*.iml
+
+target/*
+
+.settings/*
+.project
+.classpath

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
    <artifactId>KDF</artifactId>
    <version>1.0.0-SNAPSHOT</version>
    <name>KingdomFactions</name>
-   <description />
+
    <build>
       <sourceDirectory>src</sourceDirectory>
       <resources>
@@ -44,6 +44,7 @@
          </plugin>
       </plugins>
    </build>
+
    <repositories>
       <repository>
          <id>sk89q-repo</id>
@@ -58,6 +59,7 @@
          <url>http://repo.mikeprimm.com</url>
       </repository>
    </repositories>
+
    <dependencies>
       <dependency>
          <groupId>org.spigotmc</groupId>
@@ -96,4 +98,5 @@
          <scope>provided</scope>
       </dependency>
    </dependencies>
+
 </project>

--- a/src/nl/dusdavidgames/kingdomfactions/modules/command/spawn/SpawnCommand.java
+++ b/src/nl/dusdavidgames/kingdomfactions/modules/command/spawn/SpawnCommand.java
@@ -1,0 +1,33 @@
+package nl.dusdavidgames.kingdomfactions.modules.command.spawn;
+
+import nl.dusdavidgames.kingdomfactions.modules.command.KingdomFactionsCommand;
+import nl.dusdavidgames.kingdomfactions.modules.exception.KingdomFactionsException;
+import nl.dusdavidgames.kingdomfactions.modules.player.player.online.KingdomFactionsPlayer;
+import nl.dusdavidgames.kingdomfactions.modules.settings.Setting;
+import nl.dusdavidgames.kingdomfactions.modules.utils.Messages;
+import nl.dusdavidgames.kingdomfactions.modules.utils.TeleportationAction;
+
+/**
+ * Created by Jan on 21-6-2017.
+ */
+public class SpawnCommand extends KingdomFactionsCommand {
+    public SpawnCommand(String name, String permission, String info, String usage, boolean sub, boolean allowConsole) {
+        super(name, permission, info, usage, sub, allowConsole);
+    }
+
+    @Override
+    public void init() {
+    }
+
+    @Override
+    public void execute() throws KingdomFactionsException {
+        if (Setting.ALLOW_SPAWN.isEnabled()) {
+            KingdomFactionsPlayer player = getPlayer();
+            player.sendMessage(Messages.getInstance().getPrefix() + "We teleporteren je naar de spawn in " + 20 + " seconden.");
+            player.setAction(new TeleportationAction(player, player.getKingdom().getSpawn(), true, 20));
+        } else {
+            getPlayer().sendMessage(Messages.getInstance().getPrefix() + "Het is momenteel niet mogelijk om het Spawn Commando te gebruiken!");
+        }
+    }
+
+}

--- a/src/nl/dusdavidgames/kingdomfactions/modules/database/mysql/framework/AsyncStatement.java
+++ b/src/nl/dusdavidgames/kingdomfactions/modules/database/mysql/framework/AsyncStatement.java
@@ -1,0 +1,16 @@
+package nl.dusdavidgames.kingdomfactions.modules.database.mysql.framework;
+
+import nl.dusdavidgames.kingdomfactions.KingdomFactionsPlugin;
+import nl.dusdavidgames.kingdomfactions.modules.database.mysql.MySQLModule;
+import org.bukkit.Bukkit;
+
+/**
+ * Created by Jan on 21-6-2017.
+ */
+public class AsyncStatement {
+
+    public AsyncStatement(String statement) {
+        Bukkit.getScheduler().runTaskAsynchronously(KingdomFactionsPlugin.getInstance(), () -> MySQLModule.getInstance().insertQuery(statement));
+    }
+
+}

--- a/src/nl/dusdavidgames/kingdomfactions/modules/mine/DelayedPlayerTeleportEvent.java
+++ b/src/nl/dusdavidgames/kingdomfactions/modules/mine/DelayedPlayerTeleportEvent.java
@@ -1,0 +1,44 @@
+package nl.dusdavidgames.kingdomfactions.modules.mine;
+
+import lombok.Getter;
+import nl.dusdavidgames.kingdomfactions.modules.player.PlayerModule;
+import nl.dusdavidgames.kingdomfactions.modules.player.player.online.KingdomFactionsPlayer;
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+import org.bukkit.event.player.PlayerTeleportEvent;
+
+/**
+ * Created by Jan on 21-6-2017.
+ */
+public class DelayedPlayerTeleportEvent extends Event {
+
+    private static final HandlerList handlers = new HandlerList();
+
+    private @Getter final KingdomFactionsPlayer player;
+    private @Getter Location from;
+    private @Getter Location to;
+    private @Getter final PlayerTeleportEvent.TeleportCause cause;
+
+    public DelayedPlayerTeleportEvent(Player player, Location from, Location to, PlayerTeleportEvent.TeleportCause cause) {
+        this.player = PlayerModule.getInstance().getPlayer(player);
+        this.from = from;
+        this.to = to;
+        this.cause = cause;
+    }
+
+    public DelayedPlayerTeleportEvent(PlayerTeleportEvent e) {
+        this(e.getPlayer(), e.getFrom(), e.getTo(), e.getCause());
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return handlers;
+    }
+
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+
+}

--- a/src/nl/dusdavidgames/kingdomfactions/modules/mine/listeners/PlayerTeleportEventListener.java
+++ b/src/nl/dusdavidgames/kingdomfactions/modules/mine/listeners/PlayerTeleportEventListener.java
@@ -1,0 +1,24 @@
+package nl.dusdavidgames.kingdomfactions.modules.mine.listeners;
+
+import nl.dusdavidgames.kingdomfactions.KingdomFactionsPlugin;
+import nl.dusdavidgames.kingdomfactions.modules.mine.DelayedPlayerTeleportEvent;
+import nl.dusdavidgames.kingdomfactions.modules.utils.logger.Logger;
+import org.bukkit.Bukkit;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerTeleportEvent;
+
+/**
+ * Created by Jan on 21-6-2017.
+ */
+public class PlayerTeleportEventListener implements Listener {
+
+    @EventHandler
+    public void onTeleport(final PlayerTeleportEvent e) {
+        Bukkit.getScheduler().runTaskLater(KingdomFactionsPlugin.getInstance(), () -> {
+                Logger.DEBUG.log("Calling TeleportEvent");
+                Bukkit.getPluginManager().callEvent(new DelayedPlayerTeleportEvent(e));
+        }, 40L);
+    }
+
+}

--- a/src/nl/dusdavidgames/kingdomfactions/modules/utils/TeleportationAction.java
+++ b/src/nl/dusdavidgames/kingdomfactions/modules/utils/TeleportationAction.java
@@ -1,0 +1,70 @@
+package nl.dusdavidgames.kingdomfactions.modules.utils;
+
+import net.md_5.bungee.api.ChatColor;
+import nl.dusdavidgames.kingdomfactions.modules.exception.KingdomFactionsException;
+import nl.dusdavidgames.kingdomfactions.modules.player.player.online.KingdomFactionsPlayer;
+import nl.dusdavidgames.kingdomfactions.modules.utils.action.IAction;
+import org.bukkit.Location;
+
+public class TeleportationAction implements IAction {
+
+    private Location location;
+    private int delay;
+    private boolean cancelOnMove;
+    private KingdomFactionsPlayer player;
+
+    public TeleportationAction(KingdomFactionsPlayer player, Location location, boolean cancelOnMove, int delay) {
+        this.delay = delay;
+        this.cancelOnMove = cancelOnMove;
+        this.location = location;
+        this.player = player;
+    }
+
+    public Location getLocation() {
+        return location;
+    }
+
+    public int getDelay() {
+        return delay;
+    }
+
+    public boolean shouldCancelOnMove() {
+        return cancelOnMove;
+    }
+
+    public KingdomFactionsPlayer getPlayer() {
+        return player;
+    }
+
+    public void execute() throws KingdomFactionsException {
+        getPlayer().sendActionbar(ChatColor.RED + "Teleporteren...");
+        getPlayer().teleport(location);
+        cancel();
+    }
+
+    public void notifyPlayerOnMovement() {
+        if (!shouldCancelOnMove()) {
+            return;
+        }
+        getPlayer().sendMessage(Messages.getInstance().getPrefix() + "Je bewoog! De actie is geannuleerd.");
+        cancel();
+    }
+
+    public void notifyPlayerOnDelayChange() {
+        getPlayer().sendActionbar(ChatColor.RED + "Je teleporteert over " + this.delay + " seconde(n)!");
+    }
+
+    public void handleDelayChange() {
+        if (delay <= 1) {
+            try {
+                execute();
+            } catch (KingdomFactionsException e) {
+                e.printStackTrace();
+            }
+        } else {
+            delay -= 1;
+            notifyPlayerOnDelayChange();
+        }
+    }
+
+}

--- a/src/nl/dusdavidgames/kingdomfactions/modules/wreckingball/BlockWreckedEvent.java
+++ b/src/nl/dusdavidgames/kingdomfactions/modules/wreckingball/BlockWreckedEvent.java
@@ -1,0 +1,22 @@
+package nl.dusdavidgames.kingdomfactions.modules.wreckingball;
+
+import org.bukkit.block.Block;
+import org.bukkit.entity.Player;
+import org.bukkit.event.block.BlockBreakEvent;
+
+/**
+ * Created by Jan on 21-6-2017.
+ */
+public class BlockWreckedEvent extends BlockBreakEvent {
+
+    public BlockWreckedEvent(Block block, Player player) {
+        super(block, player);
+    }
+
+    //breaking blocks with a wrecking ball cannot be cancelled whatsoever
+    @Override
+    public boolean isCancelled() {
+        return false;
+    }
+
+}

--- a/src/nl/dusdavidgames/kingdomfactions/modules/wreckingball/WreckingBallListeners.java
+++ b/src/nl/dusdavidgames/kingdomfactions/modules/wreckingball/WreckingBallListeners.java
@@ -1,5 +1,6 @@
 package nl.dusdavidgames.kingdomfactions.modules.wreckingball;
 
+import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -19,46 +20,51 @@ public class WreckingBallListeners implements Listener {
 	
 	@EventHandler
 	public void onUse(PlayerInteractEvent e) {
+
 		try {
-		if(e.getAction() != Action.LEFT_CLICK_BLOCK)  {
-			return;
+			if (e.getAction() != Action.LEFT_CLICK_BLOCK) {
+				return;
+			}
+			if (e.getItem() == null) return;
+			if (!e.getItem().hasItemMeta()) return;
+			if (!e.getItem().getItemMeta().getDisplayName().equalsIgnoreCase(WreckingBallModule.WRECKINGBALL_NAME))
+				return;
+			if (e.isCancelled()) return;
+			KingdomFactionsPlayer player = PlayerModule.getInstance().getPlayer(e.getPlayer());
+			if (player.isVanished()) return;
+			if (!player.isStaff()) {
+				player.getInventory().setItem(player.getInventory().getHeldItemSlot(), null);
+				player.sendMessage(Messages.getInstance().getPrefix() + "Het is voor jou niet toegestaan om dit item te gebruiken");
+				return;
+			}
+
+			if (e.getClickedBlock() == null) return;
+			if (e.isCancelled()) return;
+
+			BlockWreckedEvent ev = new BlockWreckedEvent(e.getClickedBlock(), player.getPlayer());
+			Bukkit.getPluginManager().callEvent(ev);
+
+			e.getClickedBlock().breakNaturally();
+
+		} catch (NullPointerException npe) {
+			//bad practise!
 		}
-		if(e.getItem() == null) return;
-		if(!e.getItem().hasItemMeta()) return;
-		if(!e.getItem().getItemMeta().getDisplayName().equalsIgnoreCase(WreckingBallModule.WRECKINGBALL_NAME)) return;
-		if(e.isCancelled()) return;
-		KingdomFactionsPlayer player = PlayerModule.getInstance().getPlayer(e.getPlayer());
-		if(player.isVanished()) return;
-		if(!player.isStaff()) {
-			player.getInventory().setItem(player.getInventory().getHeldItemSlot(), null);
-			player.sendMessage(Messages.getInstance().getPrefix() + "Het is voor jou niet toegestaan om dit item te gebruiken");
-			return;
-		}
-	
-		if(e.getClickedBlock() == null) return;
-		if(e.isCancelled()) return;
-	
-		BlockWreckedEvent ev = new BlockWreckedEvent(e.getClickedBlock(), player.getPlayer());
-		if(ev.isCancelled()) return;
-		e.getClickedBlock().breakNaturally();
-		} catch(NullPointerException ex) {
-			
-		}
+
 	}
 	
 	
 	@EventHandler
 	public void onDrop(PlayerDropItemEvent e) {
 		try {
-	  ItemStack i =e.getItemDrop().getItemStack();
-	  if(i.getType() != Material.FIREBALL) return;
-	  if(!i.hasItemMeta()) return;
-	  if(i.getItemMeta().getDisplayName().equalsIgnoreCase(WreckingBallModule.WRECKINGBALL_NAME)) {
-		  e.getItemDrop().remove();
-	  }
-	} catch(NullPointerException ex) {
-		
-	}
+	  		ItemStack i = e.getItemDrop().getItemStack();
+	  		if(i.getType() != Material.FIREBALL) return;
+	  		if(!i.hasItemMeta()) return;
+	  		if(i.getItemMeta().getDisplayName().equalsIgnoreCase(WreckingBallModule.WRECKINGBALL_NAME)) {
+		  		e.getItemDrop().remove();
+	  		}
+		} catch(NullPointerException ex) {
+			//bad practise!
+		}
 	}
 	
 	@EventHandler
@@ -69,6 +75,6 @@ public class WreckingBallListeners implements Listener {
 		}
 		if(NexusModule.getInstance().isNexus(e.getBlock())) return;
 		if(BuildModule.getInstance().isBuilding(e.getBlock())) return;
-        
 	}
+
 }


### PR DESCRIPTION
Deze PR voegt de missende classes weer toe aan het project. Een aantal zijn ge-reverse-engineered vanuit de Jar die beschikbaar is gemaakt, en een enkele is naar common sense geïmplementeerd. Dit fixt issue https://github.com/ThEWiZ76/KingdomFactions/issues/1

De plugin compilet nu, maar ik heb hem niet getest in de server.